### PR TITLE
fix for remote images on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         repositories {
             google()
             jcenter()
+            maven {url 'https://plugins.gradle.org/m2/' }
         }
         
         dependencies {
@@ -35,6 +36,8 @@ repositories {
     flatDir { dirs 'libs' }
     google()
     maven { url "https://jitpack.io" }
+    // org.jetbrains.trove4j:trove4j:20160824.
+    maven { url 'https://plugins.gradle.org/m2/' }
 }
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -513,7 +513,7 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
 
                         int width = icon.getInt("width");
                         int height = icon.getInt("height");
-                        rangeSeparator.setIcon(DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
+                        rangeSeparator.setIcon(DrawableUtils.drawableFromUrl(chart.getContext(), bundle.getString("uri"), width, height));
                     }
                     if (BridgeUtils.validate(rangeSeparatorsMap, ReadableType.Number, "iconXOffset")) {
                         rangeSeparator.setIconXOffset(rangeSeparatorsMap.getInt("iconXOffset"));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/BarDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/BarDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -29,7 +31,7 @@ public class BarDataExtract extends DataExtract<BarData, BarEntry> {
     }
 
     @Override
-    BarEntry createEntry(ReadableArray values, int index) {
+    BarEntry createEntry(Context context, ReadableArray values, int index) {
         BarEntry entry;
 
         float x = index;

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/BubbleDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/BubbleDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -46,7 +48,7 @@ public class BubbleDataExtract extends DataExtract<BubbleData, BubbleEntry> {
     }
 
     @Override
-    BubbleEntry createEntry(ReadableArray values, int index) {
+    BubbleEntry createEntry(Context context, ReadableArray values, int index) {
         if (!ReadableType.Map.equals(values.getType(index))) {
             throw new IllegalArgumentException("Invalid BubbleEntry data");
         }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/CandleDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/CandleDataExtract.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
 import android.graphics.Paint;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -70,7 +71,7 @@ public class CandleDataExtract extends DataExtract<CandleData, CandleEntry> {
     }
 
     @Override
-    CandleEntry createEntry(ReadableArray values, int index) {
+    CandleEntry createEntry(Context context, ReadableArray values, int index) {
         if (!ReadableType.Map.equals(values.getType(index))) {
             throw new IllegalArgumentException();
         }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -64,7 +66,7 @@ public class CombinedDataExtract extends DataExtract<CombinedData, Entry> {
     }
 
     @Override
-    Entry createEntry(ReadableArray values, int index) {
+    Entry createEntry(Context context, ReadableArray values, int index) {
         throw new UnsupportedOperationException();
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -33,7 +35,7 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
             ReadableArray values = dataSetReadableMap.getArray("values");
             String label = dataSetReadableMap.getString("label");
 
-            ArrayList<U> entries = createEntries(values);
+            ArrayList<U> entries = createEntries(chart.getContext(), values);
 
             IDataSet<U> dataSet = createDataSet(entries, label);
 
@@ -61,17 +63,17 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
 
     abstract void dataSetConfig(Chart chart, IDataSet<U> dataSet, ReadableMap config);
 
-    ArrayList<U> createEntries(ReadableArray yValues) {
+    ArrayList<U> createEntries(Context context, ReadableArray yValues) {
         ArrayList<U> entries = new ArrayList<>(yValues.size());
         for (int j = 0; j < yValues.size(); j++) {
             if (!yValues.isNull(j)) {
-                entries.add(createEntry(yValues, j));
+                entries.add(createEntry(context, yValues, j));
             }
         }
         return entries;
     }
 
-    abstract U createEntry(ReadableArray values, int index);
+    abstract U createEntry(Context context,ReadableArray values, int index);
 
 
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -97,7 +99,7 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
     }
 
     @Override
-    Entry createEntry(ReadableArray values, int index) {
+    Entry createEntry(Context context, ReadableArray values, int index) {
         float x = index;
 
         Entry entry;
@@ -112,7 +114,7 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
                 ReadableMap bundle = icon.getMap("bundle");
                 int width = icon.getInt("width");
                 int height = icon.getInt("height");
-                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
+                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(context, bundle.getString("uri"), width, height));
 
             } else {
                 entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/PieDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/PieDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -77,7 +79,7 @@ public class PieDataExtract extends DataExtract<PieData, PieEntry> {
     }
 
     @Override
-    PieEntry createEntry(ReadableArray values, int index) {
+    PieEntry createEntry(Context context, ReadableArray values, int index) {
         PieEntry entry;
 
         if (ReadableType.Map.equals(values.getType(index))) {

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/RadarDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/RadarDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -40,7 +42,7 @@ public class RadarDataExtract extends DataExtract<RadarData, RadarEntry> {
     }
 
     @Override
-    RadarEntry createEntry(ReadableArray values, int index) {
+    RadarEntry createEntry(Context context, ReadableArray values, int index) {
         RadarEntry entry;
 
         if (ReadableType.Map.equals(values.getType(index))) {

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -56,7 +58,7 @@ public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
     }
 
     @Override
-    Entry createEntry(ReadableArray values, int index) {
+    Entry createEntry(Context context, ReadableArray values, int index) {
         float x = index;
 
         Entry entry;
@@ -70,7 +72,7 @@ public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
                 ReadableMap bundle = icon.getMap("bundle");
                 int width = icon.getInt("width");
                 int height = icon.getInt("height");
-                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
+                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(context, bundle.getString("uri"), width, height));
 
             } else {
               entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.utils;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -8,19 +9,28 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.os.AsyncTask;
 
+import com.github.wuxudong.rncharts.BuildConfig;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class DrawableUtils {
-    public static Drawable drawableFromUrl(String url, final int width, final int height) {
-        try {
-            return new DrawableLoadingAsyncTask().execute(url, Integer.toString(width), Integer.toString(height)).get();
-        } catch (Exception e) {
-            // draw dummy drawable when execution fail
-            e.printStackTrace();
-            return new ShapeDrawable();
+    public static Drawable drawableFromUrl(Context context, String url, final int width, final int height) {
+        if (BuildConfig.BUILD_TYPE == "debug") {
+            try {
+                return new DrawableLoadingAsyncTask().execute(url, Integer.toString(width), Integer.toString(height)).get();
+            } catch (Exception e) {
+                // draw dummy drawable when execution fail
+                e.printStackTrace();
+                return new ShapeDrawable();
+            }
+        } else {
+            int resourceId = context.getResources().getIdentifier(url, "drawable", context.getPackageName());
+
+            Bitmap image = BitmapFactory.decodeResource(context.getResources(), resourceId);
+            return new BitmapDrawable(Resources.getSystem(), Bitmap.createScaledBitmap(image, width, height, true));
         }
     }
 


### PR DESCRIPTION
Error report: https://github.com/facebook/react-native/issues/24963

We need this to avoid loading remove images in the chart. That was causing performance issues on Android. Now, local images are loaded in Android even in production builds 🎉 